### PR TITLE
remove peer dependency (schema-form-bootstrap)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,6 @@
     "tests"
   ],
   "dependencies": {
-    "angular-schema-form": "1.0.0-alpha.5"
   },
   "devDependencies": {
     "angular-ui-ace": "bower",


### PR DESCRIPTION
because     "angular-schema-form": "1.0.0-alpha.5" does not map to any public branch

(we get the right versions in our project via its main  bower.json, so no need to keep it in here)

####  Description

Add your description here

####  Fixes Related issues
- add related
- issues here

####  Checklist
- [ ] I have read and understand the CONTRIBUTIONS.md file
- [ ] I have searched for and linked related issues
- [ ] I have created test cases to ensure quick resolution of the PR is easier
- [ ] I am NOT targeting main branch
- [ ] I did NOT include the dist folder in my PR

@json-schema-form/angular-schema-form-bootstrap-lead
